### PR TITLE
Make first pass at input file serialization

### DIFF
--- a/pyqualw2/config/inputs.py
+++ b/pyqualw2/config/inputs.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from io import StringIO
 from os import PathLike
 from pathlib import Path
-from typing import Self
+from typing import ClassVar, Self
 
 import pandas as pd
 
@@ -30,6 +30,25 @@ class BaseInput(ABC):
             An object containing the data from the file
         """
 
+    @abstractmethod
+    def to_file(
+        self,
+        filename: PathLike,
+        overwrite: bool = False,
+        create_parents: bool = False,
+    ):
+        """Serialize the config to a file.
+
+        Parameters
+        ----------
+        filename : PathLike
+            Path where the data should be written
+        overwrite : bool
+            If True, overwrite an existing file
+        create_parents : bool
+            If True, create any necessary parent directories
+        """
+
 
 @dataclass
 class BathymetryInput(BaseInput):
@@ -40,6 +59,123 @@ class BathymetryInput(BaseInput):
     ignored: list[str]
     filename: PathLike | None = None
     comment: str | None = None
+
+    # This mapping defines human readable mappings that are used to relabel the input
+    # bathymetry file segment data columns. The inverse mapping is used when writing
+    # bathymetry to a csv for use by qualw2.
+    _segment_data_column_map: ClassVar[dict[str, str]] = {
+        "DLX": "DLX [m]",
+        "ELWS": "ELWS [m]",
+        "PHI0": "PHI0 [rad]",
+    }
+
+    @classmethod
+    def _ingest_segment_data(cls, df: pd.DataFrame) -> pd.DataFrame:
+        """Preprocess the raw segment data.
+
+        - Renames the (empty) first column name
+        - Transposes the data to be columnar
+        - Add in missing units
+        - Dropping nan-valued columns
+
+        Returns
+        -------
+        pd.DataFrame
+            The segment_data, transformed to a columnar format and with better column
+            names
+        """
+        segment_data = (
+            df.rename(columns={"Unnamed: 0": "SEG"})
+            .transpose()
+            .dropna(axis=0, how="any")
+            .reset_index()
+        )
+        segment_data.columns = segment_data.iloc[0]
+        segment_data = segment_data.iloc[1:]
+        return segment_data.rename(columns=cls._segment_data_column_map)
+
+    @classmethod
+    def _format_export_segment_data(cls, df: pd.DataFrame) -> pd.DataFrame:
+        """Format the segment data for export to csv.
+
+        Inverse operation of `_ingest_segment_data`.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            The segment data to be transformed
+
+        Returns
+        -------
+        pd.DataFrame
+            The segment data, transformed to row-wise format and with qualw2-compatible
+            column names
+        """
+        return df.rename(
+            columns={
+                col: raw_col for raw_col, col in cls._segment_data_column_map.items()
+            }
+        ).transpose()
+
+    @staticmethod
+    def _ingest_data(df: pd.DataFrame) -> pd.DataFrame:
+        """Preprocess the raw bathymetry data.
+
+        - Drop the last column, it's only there because of superfluous ',' separators
+        - Reorder and label the columns for human readability
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Data read from the bathymetry file. From the manual, this should be:
+
+              1st column: layer height in m
+              2nd column: segment widths in m for segment 1
+              3rd column: segment widths in m for segment 2
+              ...
+
+            Note that the segment widths for the first segment and last segment are 0
+            and for the top layer K=1 and bottom layer are also 0. On the far right-hand
+            side there is a layer # specification.
+
+        Returns
+        -------
+        pd.DataFrame
+            The preprocessed bathymetry
+        """
+        # There's an extra comma delimeter at the end of each column which results in a
+        # phantom column, so we drop that extra column here
+        df = df.drop(columns=df.columns[-1])
+
+        # Rename and reorder the columns to make more sense
+        nsegments = len(df.columns) - 2
+        df.columns = (
+            ["Layer height [m]"]
+            + [f"Width (segment {i + 1}) [m]" for i in range(nsegments)]
+            + ["Layer #"]
+        )
+
+        col_height, *col_widths, col_number = df.columns
+        return df[[col_number, col_height, *col_widths]]
+
+    @staticmethod
+    def _format_export_data(df: pd.DataFrame) -> pd.DataFrame:
+        """Format the bathymetry data for export to csv.
+
+        Inverse operation of `_ingest_data`.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Data to be exported
+
+        Returns
+        -------
+        pd.DataFrame
+            Formatted data ready for export to csv
+        """
+        col_number, col_height, *col_widths = df.columns
+        return df[[col_height, *col_widths, col_number]]
 
     @classmethod
     def from_file(cls, filename: PathLike) -> Self:
@@ -72,33 +208,18 @@ class BathymetryInput(BaseInput):
         # Read the segment data from the next 5 rows. The first of these lines SHOULD
         # contain
         #
-        #       Seg, followed by a header for each model segment, this is ignored
+        #       SEG, followed by a header for each model segment, this is ignored
         #
-        # according to the manual, but in practice I don't see 'Seg' appearing in any of
+        # according to the manual, but in practice I don't see 'SEG' appearing in any of
         # the bathymetry files so we manually replace it here.
         #
         # Also drop any nan-valued rows, they arise from superfluous comma separators at
         # the end of rows.
-        segment_data = (
+        segment_data = cls._ingest_segment_data(
             pd.read_csv(
                 StringIO("\n".join(lines[1:6])),
                 index_col=False,
             )
-            .rename(columns={"Unnamed: 0": "SEG"})
-            .transpose()
-            .dropna(axis=0, how="any")
-            .reset_index()
-        )
-        segment_data.columns = segment_data.iloc[0]
-        segment_data = segment_data.iloc[1:]
-
-        # Add some missing units
-        segment_data = segment_data.rename(
-            columns={
-                "DLX": "DLX [m]",
-                "ELWS": "ELWS [m]",
-                "PHI0": "PHI0 [rad]",
-            }
         )
 
         # 7th line: titles that are ignored by the model.
@@ -115,24 +236,13 @@ class BathymetryInput(BaseInput):
         # Note that the segment widths for the first segment and last segment are 0 and
         # for the top layer K=1 and bottom layer are also 0. On the far right-hand side
         # there is a layer # specification.
-        data = pd.read_csv(
-            StringIO("\n".join(lines[7:])),
-            index_col=False,
-            header=None,
+        data = cls._ingest_data(
+            pd.read_csv(
+                StringIO("\n".join(lines[7:])),
+                index_col=False,
+                header=None,
+            )
         )
-
-        # There's an extra comma delimeter at the end of each column which results in a
-        # phantom column, so we drop that extra column here
-        data = data.drop(columns=data.columns[-1])
-
-        # Rename and reorder the columns to make more sense
-        nsegments = len(data.columns) - 2
-        data.columns = (
-            ["Layer height [m]"]
-            + [f"Width (segment {i + 1}) [m]" for i in range(nsegments)]
-            + ["Layer #"]
-        )
-        data = data[["Layer #", "Layer height [m]"] + data.columns[1:-1].to_list()]
 
         return cls(
             filename=filename,
@@ -142,29 +252,65 @@ class BathymetryInput(BaseInput):
             data=data,
         )
 
+    def to_file(
+        self,
+        filename: PathLike,
+        overwrite: bool = False,
+        create_parents: bool = False,
+    ):
+        """Serialize the config to a csv file.
+
+        Parameters
+        ----------
+        filename : PathLike
+            Path where the data should be written
+        overwrite : bool
+            If True, overwrite an existing file
+        create_parents : bool
+            If True, create any necessary parent directories
+        """
+        path = Path(filename)
+        if path.suffix != ".csv":
+            raise NotImplementedError
+
+        _create_parents_or_fail(path, overwrite, create_parents)
+
+        with open(path, "w") as f:
+            f.write(f"{self.comment if self.comment else ''}\n")
+            self._format_export_segment_data(self.segment_data).to_csv(
+                f, sep=",", header=None
+            )
+            f.write(",".join(self.ignored) + "\n")
+            self._format_export_data(self.data).to_csv(
+                f, sep=",", index=False, header=None
+            )
+
 
 @dataclass
 class ProfileInput(BaseInput):
     """A container for profile (layer-dependent) input data."""
 
     comment: str
-    data: dict[str, pd.DataFrame]
+    data: pd.DataFrame
     profile_file: str | None
     filename: PathLike | None = None
 
     @classmethod
     def from_file(cls, filename: PathLike) -> Self:
-        """Parse a temperature profile file.
+        """Parse a profile file.
+
+        Profile files contain layer-dependent quantities, such as temperature,
+        dissolved oxygen, or total dissolved solids.
 
         Parameters
         ----------
         filename : PathLike
-            Path to a temperature profile file, e.g. mvpr1.npt
+            Path to a profile file, e.g. mvpr1.npt
 
         Returns
         -------
         Self
-            The temperature profile, total dissolved solids, and dissolved oxygen
+            An object containing the layer-dependent quantities from a profile file
         """
         if Path(filename).suffix != ".npt":
             raise NotImplementedError
@@ -209,7 +355,7 @@ class ProfileInput(BaseInput):
 
         return cls(
             filename=filename,
-            data=data,
+            data=pd.DataFrame(data=data),
             comment=comment,
             profile_file=profile_file,
         )
@@ -301,6 +447,71 @@ class ProfileInput(BaseInput):
             )
             yield name, data
 
+    def to_file(
+        self,
+        filename: PathLike,
+        overwrite: bool = False,
+        create_parents: bool = False,
+    ):
+        """Serialize the profile file to a file on disk.
+
+        Parameters
+        ----------
+        filename : PathLike
+            Path where the data should be written
+        overwrite : bool
+            If True, overwrite an existing file
+        create_parents : bool
+            If True, create any necessary parent directories
+        """
+        path = Path(filename)
+        if path.suffix != ".npt":
+            raise NotImplementedError
+
+        _create_parents_or_fail(path, overwrite, create_parents)
+
+        lines = [
+            f"Profile file: {self.profile_file if self.profile_file else None}",
+            self.comment,
+        ]
+        for name, arr in self.data.items():
+            label = self._get_label(name)
+
+            # Make the "column" headers
+            lines.append(f"{name:8}" + "".join(f"{label:>8}" for _ in range(9)))
+
+            # Write the data in 9 "columns", wrapping as needed to print all the data
+            for row in arr.to_numpy().reshape((-1, 9)):
+                lines.append("        " + "".join(f"{val:>8.2f}" for val in row))
+            lines.append("")
+
+        with open(path, "w") as f:
+            f.write("\n".join(lines))
+
+    @staticmethod
+    def _get_label(name: str) -> str:
+        """Get the "column" label for a layer-dependent quantity.
+
+        Parameters
+        ----------
+        name : str
+            Name of the layer-dependent quantity
+
+        Returns
+        -------
+        str
+            "Column" label to use when writing to a .npt profile file
+        """
+        low = name.lower()
+        if low.startswith("temp"):
+            return "T1"
+        elif low.startswith("tds"):
+            return "C1"
+        elif low.startswith("do"):
+            return "C2"
+        else:
+            raise NotImplementedError
+
 
 @dataclass
 class W2ConSimpleInput(BaseInput):
@@ -316,17 +527,17 @@ class W2ConSimpleInput(BaseInput):
 
     @classmethod
     def from_file(cls, filename: PathLike) -> Self:
-        """Parse a w2_con.csv profile file.
+        """Parse a qualw2 config file.
 
         Parameters
         ----------
         filename : PathLike
-            Path to a temperature profile file, e.g. mvpr1.npt
+            Path to a qualw2 config file, e.g. w2_con.csv
 
         Returns
         -------
         Self
-            The temperature profile, total dissolved solids, and dissolved oxygen
+            A simple object wrapping the content of a w2_con.csv file
         """
         if Path(filename).suffix != ".csv":
             raise NotImplementedError
@@ -343,6 +554,31 @@ class W2ConSimpleInput(BaseInput):
                 )
 
         raise ValueError(f"Unable to find the time card in {filename}")
+
+    def to_file(
+        self,
+        filename: PathLike,
+        overwrite: bool = False,
+        create_parents: bool = False,
+    ):
+        """Serialize the config to a csv file.
+
+        Parameters
+        ----------
+        filename : PathLike
+            Path where the data should be written
+        overwrite : bool
+            If True, overwrite an existing file
+        create_parents : bool
+            If True, create any necessary parent directories
+        """
+        path = Path(filename)
+        if path.suffix != ".csv":
+            raise NotImplementedError
+
+        _create_parents_or_fail(path, overwrite, create_parents)
+        with open(path, "w") as f:
+            f.write(self.content)
 
     @property
     def timedata(self) -> tuple[float, float, int]:
@@ -371,3 +607,26 @@ class W2ConSimpleInput(BaseInput):
         _, _, _, *rest = lines[self.time_lineno].split(",")
         lines[self.time_lineno] = ",".join([str(tmstart), str(tmend), str(year), *rest])
         self.content = "".join(lines)
+
+
+def _create_parents_or_fail(
+    path: PathLike,
+    overwrite: bool = False,
+    create_parents: bool = True,
+):
+    path = Path(path)
+    if path.exists():
+        if not overwrite:
+            raise OSError(
+                f"Cannot write file to {path}; a file already exists there. To "
+                "overwrite it, pass `overwrite=True`."
+            )
+    else:
+        if not path.parent.exists():
+            if create_parents:
+                path.parent.mkdir(parents=True, exist_ok=True)
+            else:
+                raise OSError(
+                    f"Parent directory {path.parent} does not exist. Aborting. "
+                    "To create the parent directory, pass `create_parents=True`."
+                )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -11,17 +11,17 @@ def sample_data() -> Path:
 
 @pytest.fixture
 def sample_w2_con(sample_data) -> Path:
-    """Get the path to the w2_con file."""
+    """Get the path to an example w2_con.csv file."""
     return sample_data / "w2_con.csv"
 
 
 @pytest.fixture
 def sample_bathymetry(sample_data) -> Path:
-    """Get the path to the bathymetry file."""
+    """Get the path to an example bathymetry file."""
     return sample_data / "mbth_wb1.csv"
 
 
 @pytest.fixture
-def sample_temperature(sample_data) -> Path:
-    """Get the path to the temperature file."""
+def sample_profile(sample_data) -> Path:
+    """Get the path to an example profile file."""
     return sample_data / "mvpr1.npt"


### PR DESCRIPTION
This PR makes a first pass at input file serialization.

- A new abstract method was added in the `BaseInput` class: `to_file`
- Refactored some of the data ingestion logic for the bathymetry, since we need to undo some of that when we write to disk so that qualw2 can use it
- Profile data is now stored in a `DataFrame`, rather than `dict[str, NDArray]`
- Added tests for new `to_file` methods

Closes #24.